### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Kazuho1222/employee-import/security/code-scanning/1](https://github.com/Kazuho1222/employee-import/security/code-scanning/1)

To resolve the problem, we should add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimum required privileges. The recommended minimal starting point is `contents: read`, which allows jobs to read repository contents but not to perform write actions (such as pushing code or publishing releases). 

This block can be placed either at the root of the workflow file—thus affecting all jobs (and this is preferred when all jobs require only the same privileges)—or within the specific job (e.g., under `jobs.ci`). As this workflow only has one job (`ci`), either location is equivalent, but the root is preferred for clarity and future extensibility.

So, add the following block immediately after the `name: tests` declaration and before `on: ...` (between lines 1 and 2):

```yaml
permissions:
  contents: read
```

No new dependencies or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
